### PR TITLE
fix error message for errNotAvailable

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -29,7 +29,7 @@ const (
 
 var (
 	// errNotAvailable returned when func called that is not supported in cluster mode
-	errNotAvailable = errors.New("not available when GroupID is set")
+	errNotAvailable = errors.New("unavailable when GroupID is not set")
 )
 
 const (


### PR DESCRIPTION
The error message read opposite to what the intended behavior is. This is a small change to better represent the invalid use case the error message describes.